### PR TITLE
Use new Rollup output file prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ export default function css (options = {}) {
         }
 
         // Guess destination filename
-        dest = opts.dest || 'bundle.js'
+        dest = opts.file || 'bundle.js'
         if (dest.endsWith('.js')) {
           dest = dest.slice(0, -3)
         }


### PR DESCRIPTION
`opts.dest` was deprecated around rollup@0.51.6, see:
https://github.com/rollup/rollup/commit/30cd1caeaa2e4741c98fc2311e43afbefd89142b